### PR TITLE
Update Python scripts to latest JSON2DA and update BaseEyeItemOneEye header to match new dumped UHT headers from latest T8 update

### DIFF
--- a/Source/Polaris/Private/BaseEyeItemOneEye.cpp
+++ b/Source/Polaris/Private/BaseEyeItemOneEye.cpp
@@ -1,6 +1,7 @@
 #include "BaseEyeItemOneEye.h"
 
 FBaseEyeItemOneEye::FBaseEyeItemOneEye() {
+    this->EyeMaterialOverride_Param = NULL;
     this->Sclera_Param = NULL;
     this->IrisColor_Param = NULL;
     this->IrisEmmisive_Param = 0.00f;

--- a/Source/Polaris/Public/BaseEyeItemOneEye.h
+++ b/Source/Polaris/Public/BaseEyeItemOneEye.h
@@ -4,11 +4,15 @@
 #include "BaseEyeItemOneEye.generated.h"
 
 class UTexture;
+class UMaterialInstance;
 
 USTRUCT(BlueprintType)
 struct POLARIS_API FBaseEyeItemOneEye {
     GENERATED_BODY()
 public:
+    UPROPERTY(BlueprintReadWrite, EditAnywhere, meta = (AllowPrivateAccess = true))
+    UMaterialInstance* EyeMaterialOverride_Param;
+
     UPROPERTY(BlueprintReadWrite, EditAnywhere, meta=(AllowPrivateAccess=true))
     UTexture* Sclera_Param;
     


### PR DESCRIPTION
 - Update Python scripts to latest JSON2DA 
 - Update BaseEyeItemOneEye header to match new dumped UHT headers from latest T8 update